### PR TITLE
Fix deploy workflow failing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ jobs:
 
   deploy:
     runs-on: windows-latest
+    needs: build
 
     steps:
       - name: Checkout

--- a/NLua/NLua.csproj
+++ b/NLua/NLua.csproj
@@ -7,7 +7,7 @@
             original Copyright © Vinicius Jarina 2019
             modified by Copyright (c) Buerkert Fluid Control Systems 2026
         </Copyright>
-        <VersionPrefix>1.8.0</VersionPrefix>
+        <VersionPrefix>1.7.0</VersionPrefix>
         <VersionSuffix>branch</VersionSuffix>
         <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>


### PR DESCRIPTION
Due to `deploy` currently not depending on `build`, it tries to run directly at which point the required artifacts are still missing. 